### PR TITLE
qtwebengine: Fix illegal instruction crash on rpi4

### DIFF
--- a/recipes-qt/qt6/qtwebengine.inc
+++ b/recipes-qt/qt6/qtwebengine.inc
@@ -42,5 +42,7 @@ SRC_URI += " \
     file://chromium/0007-Remove-unsetting-_FILE_OFFSET_BITS.patch;patchdir=src/3rdparty \
     file://chromium/0003-avcodec-x86-mathops-clip-constants-used-with-shift-i.patch;patchdir=src/3rdparty \
 "
+# Machines not supporting AES instructions e.g. RPI4 need to disable  assembly in boringssl
+SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://chromium/boringssl_no_asm_config.patch;patchdir=src/3rdparty', d)}"
 
 SRCREV_FORMAT = "qtwebengine_qtwebengine-chromium"

--- a/recipes-qt/qt6/qtwebengine/chromium/boringssl_no_asm_config.patch
+++ b/recipes-qt/qt6/qtwebengine/chromium/boringssl_no_asm_config.patch
@@ -1,0 +1,18 @@
+Disable assembly routines on arm64/rpi4 since it uses
+AES crypto extensions and these extensions do not exist in rpi4
+
+This fixes random SIGILL seen in aes_hw_set_encrypt_key() on rpi4-64
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+--- a/chromium/third_party/boringssl/BUILD.gn
++++ b/chromium/third_party/boringssl/BUILD.gn
+@@ -92,7 +92,7 @@ if (is_win && !is_msan && current_cpu !=
+         public_configs = [ ":no_asm_config" ]
+       }
+     } else if (current_cpu == "arm64") {
+-      if (is_linux || is_chromeos || is_android) {
++      if (is_chromeos || is_android) {
+         sources += crypto_sources_linux_aarch64
+       } else if (is_apple) {
+         sources += crypto_sources_apple_aarch64


### PR DESCRIPTION
When compiling for rpi6/64-bit qtwebengine ends up crashing in boringSSL because default is to use assembly routines for armv8 for performance reasons, however, these assembly routines assume that machine is capable of running AES crypto instructions which may not be true on all armv8 based machines e.g. rpi3/rpi4

Change-Id: I13d495a660497e3424b7e5cc4ddd23cf29838796