### PR TITLE
nativesdk-packagegroup-qt6-toolchain-host: Use inherit defer for nati…

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host.bb
@@ -1,7 +1,8 @@
 DESCRIPTION = "Qt6 development host packages"
 LICENSE = "MIT"
 
-inherit packagegroup nativesdk
+inherit packagegroup
+inherit_defer nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 


### PR DESCRIPTION
…vesdk

This fixes a QA warnings appearing after packagegroup bbclass started using inherit_defer which means classes started appearing after nativesdk in inherit order.

Fixes
ERROR: /mnt/b/yoe/master/sources/meta-qt6/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host.bb: QA Issue: nativesdk-packagegroup-qt6-toolchain-host: native/nativesdk class is not inherited last, this can result in unexpected behavior. Classes inherited after native/nativesdk: allarch.bbclass [native -last]
ERROR: /mnt/b/yoe/master/sources/meta-qt6/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host.bb: Fatal QA errors were found, failing task.

Change-Id: I57a20c8be78f09284db048569ddfd8e437579987