### PR TITLE
Fixes needed to build qtwebengine 6.6 with upcoming clang-18 release.

### DIFF
--- a/recipes-qt/qt6/qtwebengine.inc
+++ b/recipes-qt/qt6/qtwebengine.inc
@@ -40,6 +40,7 @@ SRC_URI += " \
     file://chromium/0004-Replace-imp.load_source-with-importlib-equivalent.patch;patchdir=src/3rdparty \
     file://chromium/0005-Remove-the-GN-settings-done-for-clang-that-conflict-.patch;patchdir=src/3rdparty \
     file://chromium/0006-267f9bd.patch;patchdir=src/3rdparty \
+    file://chromium/0007-csp_validator.cc-Explicitly-delete-default-copy-cons.patch;patchdir=src/3rdparty \
 "
 # Machines not supporting AES instructions e.g. RPI4 need to disable  assembly in boringssl
 SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://chromium/boringssl_no_asm_config.patch;patchdir=src/3rdparty', d)}"

--- a/recipes-qt/qt6/qtwebengine.inc
+++ b/recipes-qt/qt6/qtwebengine.inc
@@ -38,6 +38,7 @@ SRC_URI += " \
     file://chromium/0002-mojom-Drop-using-imp-module.patch;patchdir=src/3rdparty \
     file://chromium/0003-Update-vendored-copy-of-six-to-1.16.0.patch;patchdir=src/3rdparty \
     file://chromium/0004-Replace-imp.load_source-with-importlib-equivalent.patch;patchdir=src/3rdparty \
+    file://chromium/0005-Remove-the-GN-settings-done-for-clang-that-conflict-.patch;patchdir=src/3rdparty \
 "
 # Machines not supporting AES instructions e.g. RPI4 need to disable  assembly in boringssl
 SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://chromium/boringssl_no_asm_config.patch;patchdir=src/3rdparty', d)}"

--- a/recipes-qt/qt6/qtwebengine.inc
+++ b/recipes-qt/qt6/qtwebengine.inc
@@ -39,6 +39,7 @@ SRC_URI += " \
     file://chromium/0003-Update-vendored-copy-of-six-to-1.16.0.patch;patchdir=src/3rdparty \
     file://chromium/0004-Replace-imp.load_source-with-importlib-equivalent.patch;patchdir=src/3rdparty \
     file://chromium/0005-Remove-the-GN-settings-done-for-clang-that-conflict-.patch;patchdir=src/3rdparty \
+    file://chromium/0006-267f9bd.patch;patchdir=src/3rdparty \
 "
 # Machines not supporting AES instructions e.g. RPI4 need to disable  assembly in boringssl
 SRC_URI:append:aarch64 = "${@bb.utils.contains('TUNE_FEATURES', 'crypto', '', ' file://chromium/boringssl_no_asm_config.patch;patchdir=src/3rdparty', d)}"

--- a/recipes-qt/qt6/qtwebengine/chromium/0005-Remove-the-GN-settings-done-for-clang-that-conflict-.patch
+++ b/recipes-qt/qt6/qtwebengine/chromium/0005-Remove-the-GN-settings-done-for-clang-that-conflict-.patch
@@ -1,0 +1,87 @@
+From 7eb6877c15ab9d73c9a7cf3a8a17a1a23f7396f9 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 29 Apr 2019 12:00:19 +0300
+Subject: [PATCH] Remove the GN settings done for clang that conflict with OE
+
+clang cross compiler that is build with meta-clang has lot of these
+settings built-in and specifying them here confuses the compiler
+
+--target option and -no-canonical-prefixes options result in clang
+
+finding the headers in target sysroot
+
+Upstream-Status: Inappropriate [OE-Specific]
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Rebased-by: Maksim Sisov <msisov@igalia.com>
+Rebased-by: Randy MacLeod <randy.macleod@windriver.com>
+
+---
+ build/config/compiler/BUILD.gn | 38 ----------------------------------
+ 1 file changed, 38 deletions(-)
+
+--- a/chromium/build/config/compiler/BUILD.gn
++++ b/chromium/build/config/compiler/BUILD.gn
+@@ -1065,11 +1065,6 @@ config("compiler_cpu_abi") {
+         ]
+       }
+     } else if (current_cpu == "arm") {
+-      if (is_clang && !is_android && !is_nacl &&
+-          !(is_chromeos_lacros && is_chromeos_device)) {
+-        cflags += [ "--target=arm-linux-gnueabihf" ]
+-        ldflags += [ "--target=arm-linux-gnueabihf" ]
+-      }
+       if (!is_nacl) {
+         cflags += ["-mfloat-abi=$arm_float_abi"]
+         if (arm_arch != "") {
+@@ -1082,12 +1077,6 @@ config("compiler_cpu_abi") {
+       if (arm_tune != "") {
+         cflags += [ "-mtune=$arm_tune" ]
+       }
+-    } else if (current_cpu == "arm64") {
+-      if (is_clang && !is_android && !is_nacl && !is_fuchsia &&
+-          !(is_chromeos_lacros && is_chromeos_device)) {
+-        cflags += [ "--target=aarch64-linux-gnu" ]
+-        ldflags += [ "--target=aarch64-linux-gnu" ]
+-      }
+     } else if (current_cpu == "mipsel" && !is_nacl) {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+@@ -1095,9 +1084,6 @@ config("compiler_cpu_abi") {
+           if (is_android) {
+             cflags += [ "--target=mipsel-linux-android" ]
+             ldflags += [ "--target=mipsel-linux-android" ]
+-          } else {
+-            cflags += [ "--target=mipsel-linux-gnu" ]
+-            ldflags += [ "--target=mipsel-linux-gnu" ]
+           }
+         } else {
+           cflags += [ "-EL" ]
+@@ -1177,8 +1163,6 @@ config("compiler_cpu_abi") {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+         if (is_clang) {
+-          cflags += [ "--target=mips-linux-gnu" ]
+-          ldflags += [ "--target=mips-linux-gnu" ]
+         } else {
+           cflags += [ "-EB" ]
+           ldflags += [ "-EB" ]
+@@ -1226,9 +1210,6 @@ config("compiler_cpu_abi") {
+           if (is_android) {
+             cflags += [ "--target=mips64el-linux-android" ]
+             ldflags += [ "--target=mips64el-linux-android" ]
+-          } else {
+-            cflags += [ "--target=mips64el-linux-gnuabi64" ]
+-            ldflags += [ "--target=mips64el-linux-gnuabi64" ]
+           }
+         } else {
+           cflags += [
+@@ -1286,8 +1267,6 @@ config("compiler_cpu_abi") {
+       ldflags += [ "-Wl,--hash-style=sysv" ]
+       if (custom_toolchain == "") {
+         if (is_clang) {
+-          cflags += [ "--target=mips64-linux-gnuabi64" ]
+-          ldflags += [ "--target=mips64-linux-gnuabi64" ]
+         } else {
+           cflags += [
+             "-EB",

--- a/recipes-qt/qt6/qtwebengine/chromium/0006-267f9bd.patch
+++ b/recipes-qt/qt6/qtwebengine/chromium/0006-267f9bd.patch
@@ -1,0 +1,114 @@
+From 267f9bdd53a37d1cbee760d5af07880198e1beef Mon Sep 17 00:00:00 2001
+From: Tommi <tommi@webrtc.org>
+Date: Thu, 21 Dec 2023 14:08:26 +0100
+Subject: [PATCH] Update LegacyStatsCollector to conform with Wc++11-narrowing
+
+Bug: none
+Change-Id: Ida6a1af5c324473a55ea4f3b143862ea016ff50a
+Reviewed-on: https://webrtc-review.googlesource.com/c/src/+/332240
+Commit-Queue: Tomas Gunnarsson <tommi@webrtc.org>
+Reviewed-by: Harald Alvestrand <hta@webrtc.org>
+Auto-Submit: Tomas Gunnarsson <tommi@webrtc.org>
+Reviewed-by: Alexander Kornienko <alexfh@google.com>
+Reviewed-by: Henrik Boström <hbos@webrtc.org>
+Cr-Commit-Position: refs/heads/main@{#41432}
+---
+
+--- a/chromium/third_party/webrtc/pc/legacy_stats_collector.cc
++++ b/chromium/third_party/webrtc/pc/legacy_stats_collector.cc
+@@ -189,9 +189,10 @@ void ExtractStats(const cricket::VoiceRe
+       {StatsReport::kStatsValueNameAccelerateRate, info.accelerate_rate},
+       {StatsReport::kStatsValueNamePreemptiveExpandRate,
+        info.preemptive_expand_rate},
+-      {StatsReport::kStatsValueNameTotalAudioEnergy, info.total_output_energy},
++      {StatsReport::kStatsValueNameTotalAudioEnergy,
++       static_cast<float>(info.total_output_energy)},
+       {StatsReport::kStatsValueNameTotalSamplesDuration,
+-       info.total_output_duration}};
++       static_cast<float>(info.total_output_duration)}};
+ 
+   const IntForAdd ints[] = {
+       {StatsReport::kStatsValueNameCurrentDelayMs, info.delay_estimate_ms},
+@@ -245,9 +246,10 @@ void ExtractStats(const cricket::VoiceSe
+   SetAudioProcessingStats(report, info.apm_statistics);
+ 
+   const FloatForAdd floats[] = {
+-      {StatsReport::kStatsValueNameTotalAudioEnergy, info.total_input_energy},
++      {StatsReport::kStatsValueNameTotalAudioEnergy,
++       static_cast<float>(info.total_input_energy)},
+       {StatsReport::kStatsValueNameTotalSamplesDuration,
+-       info.total_input_duration}};
++       static_cast<float>(info.total_input_duration)}};
+ 
+   RTC_DCHECK_GE(info.audio_level, 0);
+   const IntForAdd ints[] = {
+@@ -341,7 +343,8 @@ void ExtractStats(const cricket::VideoRe
+       {StatsReport::kStatsValueNamePlisSent, info.plis_sent},
+       {StatsReport::kStatsValueNameRenderDelayMs, info.render_delay_ms},
+       {StatsReport::kStatsValueNameTargetDelayMs, info.target_delay_ms},
+-      {StatsReport::kStatsValueNameFramesDecoded, info.frames_decoded},
++      {StatsReport::kStatsValueNameFramesDecoded,
++       static_cast<int>(info.frames_decoded)},
+   };
+ 
+   for (const auto& i : ints)
+@@ -385,15 +388,19 @@ void ExtractStats(const cricket::VideoSe
+        info.encode_usage_percent},
+       {StatsReport::kStatsValueNameFirsReceived, info.firs_rcvd},
+       {StatsReport::kStatsValueNameFrameHeightSent, info.send_frame_height},
+-      {StatsReport::kStatsValueNameFrameRateInput, round(info.framerate_input)},
++      {StatsReport::kStatsValueNameFrameRateInput,
++       static_cast<int>(round(info.framerate_input))},
+       {StatsReport::kStatsValueNameFrameRateSent, info.framerate_sent},
+       {StatsReport::kStatsValueNameFrameWidthSent, info.send_frame_width},
+-      {StatsReport::kStatsValueNameNacksReceived, info.nacks_rcvd},
++      {StatsReport::kStatsValueNameNacksReceived,
++       static_cast<int>(info.nacks_rcvd)},
+       {StatsReport::kStatsValueNamePacketsLost, info.packets_lost},
+       {StatsReport::kStatsValueNamePacketsSent, info.packets_sent},
+       {StatsReport::kStatsValueNamePlisReceived, info.plis_rcvd},
+-      {StatsReport::kStatsValueNameFramesEncoded, info.frames_encoded},
+-      {StatsReport::kStatsValueNameHugeFramesSent, info.huge_frames_sent},
++      {StatsReport::kStatsValueNameFramesEncoded,
++       static_cast<int>(info.frames_encoded)},
++      {StatsReport::kStatsValueNameHugeFramesSent,
++       static_cast<int>(info.huge_frames_sent)},
+   };
+ 
+   for (const auto& i : ints)
+@@ -782,19 +789,25 @@ StatsReport* LegacyStatsCollector::AddCo
+                 AddCandidateReport(remote_candidate_stats, false)->id());
+ 
+   const Int64ForAdd int64s[] = {
+-      {StatsReport::kStatsValueNameBytesReceived, info.recv_total_bytes},
+-      {StatsReport::kStatsValueNameBytesSent, info.sent_total_bytes},
+-      {StatsReport::kStatsValueNamePacketsSent, info.sent_total_packets},
+-      {StatsReport::kStatsValueNameRtt, info.rtt},
++      {StatsReport::kStatsValueNameBytesReceived,
++       static_cast<int64_t>(info.recv_total_bytes)},
++      {StatsReport::kStatsValueNameBytesSent,
++       static_cast<int64_t>(info.sent_total_bytes)},
++      {StatsReport::kStatsValueNamePacketsSent,
++       static_cast<int64_t>(info.sent_total_packets)},
++      {StatsReport::kStatsValueNameRtt, static_cast<int64_t>(info.rtt)},
+       {StatsReport::kStatsValueNameSendPacketsDiscarded,
+-       info.sent_discarded_packets},
++       static_cast<int64_t>(info.sent_discarded_packets)},
+       {StatsReport::kStatsValueNameSentPingRequestsTotal,
+-       info.sent_ping_requests_total},
++       static_cast<int64_t>(info.sent_ping_requests_total)},
+       {StatsReport::kStatsValueNameSentPingRequestsBeforeFirstResponse,
+-       info.sent_ping_requests_before_first_response},
+-      {StatsReport::kStatsValueNameSentPingResponses, info.sent_ping_responses},
+-      {StatsReport::kStatsValueNameRecvPingRequests, info.recv_ping_requests},
+-      {StatsReport::kStatsValueNameRecvPingResponses, info.recv_ping_responses},
++       static_cast<int64_t>(info.sent_ping_requests_before_first_response)},
++      {StatsReport::kStatsValueNameSentPingResponses,
++       static_cast<int64_t>(info.sent_ping_responses)},
++      {StatsReport::kStatsValueNameRecvPingRequests,
++       static_cast<int64_t>(info.recv_ping_requests)},
++      {StatsReport::kStatsValueNameRecvPingResponses,
++       static_cast<int64_t>(info.recv_ping_responses)},
+   };
+   for (const auto& i : int64s)
+     report->AddInt64(i.name, i.value);

--- a/recipes-qt/qt6/qtwebengine/chromium/0007-csp_validator.cc-Explicitly-delete-default-copy-cons.patch
+++ b/recipes-qt/qt6/qtwebengine/chromium/0007-csp_validator.cc-Explicitly-delete-default-copy-cons.patch
@@ -1,0 +1,40 @@
+From 8c781455b886bc677d4d063ac1ab6e8a0b3c2bb1 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Mon, 22 Jan 2024 23:36:35 -0800
+Subject: [PATCH] csp_validator.cc: Explicitly delete default copy constructor.
+
+This helps avoid ambiguity with clang 18
+
+./../../../../../git/src/3rdparty/chromium/extensions/common/csp_validator.cc:648:20: error: call to constructor of 'DirectiveMapping' is ambiguous
+  648 |   DirectiveMapping script_src_mapping({DirectiveStatus({kScriptSrc})});
+      |                    ^                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+./../../../../../git/src/3rdparty/chromium/extensions/common/csp_validator.cc:639:10: note: candidate constructor (the implicit copy constructor) has been implicitly deleted
+  639 |   struct DirectiveMapping {
+      |          ^
+./../../../../../git/src/3rdparty/chromium/extensions/common/csp_validator.cc:640:5: note: candidate constructor
+  640 |     DirectiveMapping(DirectiveStatus status) : status(std::move(status)) {}
+      |     ^
+./../../../../../git/src/3rdparty/chromium/extensions/common/csp_validator.cc:641:5: note: candidate constructor has been explicitly deleted
+  641 |     DirectiveMapping(DirectiveMapping&& ) = delete;
+      |     ^
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ chromium/extensions/common/csp_validator.cc | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/chromium/extensions/common/csp_validator.cc b/chromium/extensions/common/csp_validator.cc
+index 97204918f94..b24d99bae30 100644
+--- a/chromium/extensions/common/csp_validator.cc
++++ b/chromium/extensions/common/csp_validator.cc
+@@ -638,6 +638,7 @@ bool DoesCSPDisallowRemoteCode(const std::string& content_security_policy,
+ 
+   struct DirectiveMapping {
+     DirectiveMapping(DirectiveStatus status) : status(std::move(status)) {}
++    DirectiveMapping(DirectiveMapping& ) = delete;
+ 
+     DirectiveStatus status;
+     raw_ptr<const CSPParser::Directive, DanglingUntriaged> directive = nullptr;
+-- 
+2.43.0
+


### PR DESCRIPTION
Qtwebengine uses chromium-112 and therefore needs some fixes and backports to keep working with latest compilers. 