### PR TITLE
qtwebengine: Add missing dep on libxdamage for webrtc feature

### DIFF
--- a/recipes-qt/qt6/qtwebengine_git.bb
+++ b/recipes-qt/qt6/qtwebengine_git.bb
@@ -69,7 +69,7 @@ PACKAGECONFIG[re2] = "-DFEATURE_webengine_system_re2=ON,-DFEATURE_webengine_syst
 PACKAGECONFIG[snappy] = "-DFEATURE_webengine_system_snappy=ON,-DFEATURE_webengine_system_snappy=OFF,snappy"
 PACKAGECONFIG[spellchecker] = "-DFEATURE_webengine_spellchecker=ON,-DFEATURE_webengine_spellchecker=OFF"
 PACKAGECONFIG[webchannel] = "-DFEATURE_webengine_webchannel=ON,-DFEATURE_webengine_webchannel=OFF,qtwebchannel"
-PACKAGECONFIG[webrtc] = "-DFEATURE_webengine_webrtc=ON,-DFEATURE_webengine_webrtc=OFF,libvpx"
+PACKAGECONFIG[webrtc] = "-DFEATURE_webengine_webrtc=ON,-DFEATURE_webengine_webrtc=OFF,libvpx libxdamage"
 PACKAGECONFIG[webrtc-pipewire] = "-DFEATURE_webengine_webrtc_pipewire=ON,-DFEATURE_webengine_webrtc_pipewire=OFF,pipewire glib-2.0 libepoxy virtual/libgbm"
 PACKAGECONFIG[zlib] = "-DFEATURE_webengine_system_zlib=ON -DFEATURE_webengine_system_minizip=ON,-DFEATURE_webengine_system_zlib=OFF -DFEATURE_webengine_system_minizip,zlib minizip"
 


### PR DESCRIPTION
This fails to configure on distros which use wayland and has no X11

  ERROR: Feature "webengine_webrtc": Forcing to "ON" breaks its condition:
       XDAMAGE_FOUND OR NOT QT_FEATURE_webengine_ozone_x11
   Condition values dump:
       XDAMAGE_FOUND = ""
       QT_FEATURE_webengine_ozone_x11 = "ON"

Change-Id: Ief87700bca795bbe19be3ee21f6ee6887a5ec3c3