### PR TITLE
nativesdk-packagegroup-qt6-toolchain-host-addons: Add wayland depende…

### DIFF
--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host-addons.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt6-toolchain-host-addons.bb
@@ -21,8 +21,7 @@ RDEPENDS:${PN} += " \
     nativesdk-qtscxml-tools \
     nativesdk-qtshadertools-dev \
     nativesdk-qtshadertools-tools \
-    nativesdk-qtwayland-dev \
-    nativesdk-qtwayland-tools \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'nativesdk-qtwayland-dev nativesdk-qtwayland-tools', '', d)} \
     ${FORLINUXHOST} \
 "
 


### PR DESCRIPTION
…nt packages conditionally

This ensures that these packages are added only when wayland is enabled in DISTRO_FEATURES, since now these packages do check for this distro feature themselves, this fixes the SDK builds for eglfs distros

Change-Id: If4f231ee8999b6a7499d63d4b0bd104ab1ff510d