### PR TITLE
qt6-cmake.bbclass: add reproducibility workaround

### DIFF
--- a/classes/qt6-cmake.bbclass
+++ b/classes/qt6-cmake.bbclass
@@ -37,6 +37,17 @@ EXTRA_OECMAKE += "\
     -DINSTALL_MKSPECSDIR:PATH=${@os.path.relpath(d.getVar('QT6_INSTALL_MKSPECSDIR'), d.getVar('prefix') + '/')} \
 "
 
+do_install:prepend() {
+    [ -d  ${B}/src ] && find ${B}/src \( -name "*.h" -or -name "*.cpp" \) -prune -exec \
+        sed -i \
+            -e "s|${S}/||g" \
+            -e "s|${B}/||g" {} \;
+    [ -d  ${B}/tools ] && find ${B}/tools \( -name "*.cpp" \) -prune -exec \
+        sed -i \
+            -e "s|${S}/||g" \
+            -e "s|${B}/||g" {} \;
+}
+
 do_install:append() {
     # Replace host paths with qmake built-in properties QTBUG-84725
     find ${D} \( -name "*.pri" -or -name "*.prl" \) -exec \
@@ -46,3 +57,5 @@ do_install:append() {
 }
 
 export QT_DISABLE_SHADER_DISK_CACHE = "1"
+
+INSANE_SKIP:${PN}-ptest += "buildpaths"


### PR DESCRIPTION
oe-core made reference to buildpath an error. meta-qt6 has a lot reproducibility issues in its src and headers. Basically these are just comments. Remove them to fix build.

Test binaries have embedded build time paths. Ignore for now.